### PR TITLE
poprawiona translacja

### DIFF
--- a/src/app/index.translator.js
+++ b/src/app/index.translator.js
@@ -12,7 +12,7 @@
       prefix: '/assets/i18n/',
       suffix: '/common.json'
     });
-    $translateProvider.useSanitizeValueStrategy('sanitize');
+    $translateProvider.useSanitizeValueStrategy('escape');
     $translateProvider.preferredLanguage('pl_PL');
   }
 


### PR DESCRIPTION
Zmieniłem metodę z "sanitize" na "escape". "Sanitize" ma błąd dla UTF-8.