### PR TITLE
Poprawienie wyszukiwania talii publicznych/prywatnych.

### DIFF
--- a/src/app/deck/deck.controller.js
+++ b/src/app/deck/deck.controller.js
@@ -19,12 +19,14 @@
     vm.clear = clear;
     vm.isOpen = false;
 
+    vm.access = $stateParams.access;
+
     function getDecks(query) {
       //for not loading list of deck on page init
       if (vm.load) {
         if (!vm.decks) {
           //create request for deck list
-          vm.decks = BackendService.getDecks();
+          vm.decks = BackendService.getDecks(vm.access);
         }
         return vm.decks
           .then(function (result) {

--- a/src/app/deck/deck.route.js
+++ b/src/app/deck/deck.route.js
@@ -11,7 +11,8 @@
       .state('deck', {
         parent: 'navbar',
         url: '/deck/:deckId?',
-        templateUrl: 'app/deck/deck.page.html'
+        templateUrl: 'app/deck/deck.page.html',
+        params: {access: 'private'}
       })
       .state('deck.addCard', {
         parent: 'deck',

--- a/src/app/decks/decks.html
+++ b/src/app/decks/decks.html
@@ -2,7 +2,8 @@
   <div ng-repeat="deck in decks.categories" flex-xs="100" flex-sm="50" flex="25">
 
     <div ng-if="decks.access == 'private'">
-      <md-card class="card-square" ui-sref="deck.addCard({ deckId: deck.id })">
+      <md-card class="card-square"
+               ui-sref="deck.addCard({ deckId: deck.id, access: 'private' })">
         <div>
           <div class="title-square">
             {{ deck.name }}
@@ -12,7 +13,8 @@
     </div>
 
     <div ng-if="decks.access == 'public'">
-      <md-card class="card-square" ui-sref="deck-preview({ deckId: deck.id })">
+      <md-card class="card-square"
+               ui-sref="deck-preview({ deckId: deck.id, access: 'public' })">
         <div>
           <div class="title-square">
             {{ deck.name }}

--- a/src/assets/i18n/pl_PL/common.json
+++ b/src/assets/i18n/pl_PL/common.json
@@ -49,7 +49,7 @@
     "navbar-ADD": "Dodaj",
     "navbar-NEW_DECK": "Nowa talia",
     "navbar-NEW_CARD_FROM_FILE": "Nowa fiszka z pliku",
-    "navbar-PRIVATE_CARDS": "Moje talie",
+    "navbar-PRIVATE_CARDS": "Prywatne talie",
     "navbar-PUBLIC_CARDS": "Publiczne talie",
 
     "networkAlert-WARNING": "Uwaga!",


### PR DESCRIPTION
W wyszukiwarce talii w `/deck` będą widoczne jedynie prywatne talie, a w `/deck-preview` jedynie publiczne.

Aktualnie, wszędzie są widoczne wszystkie talie, przez co można było edytować talie publiczne. Edycja talii publicznych będzie dostępna później, gdy będzie podział na użytkowników, a więc gdy będzie wiadomo do kogo poszczególna talia należy.